### PR TITLE
refactor: improve news randomization and 404 handling

### DIFF
--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -3,21 +3,37 @@ export const onRequestGet = async (context) => {
         // 从 KV 命名空间 HOME_NEWS 读取 "all" 键
         const newsList = await context.env.HOME_NEWS.get("all", "json");
 
-        if (!newsList || !Array.isArray(newsList)) {
-            return new Response(JSON.stringify({ error: "No news data found" }), {
-                status: 500,
-                headers: { "content-type": "application/json; charset=utf-8" }
-            });
+        if (!Array.isArray(newsList)) {
+            return new Response(
+                JSON.stringify({ error: "News data not found" }),
+                {
+                    status: 404,
+                    headers: { "content-type": "application/json; charset=utf-8" }
+                }
+            );
         }
 
         // Fisher–Yates 洗牌算法（随机顺序更均匀）
         function shuffle(arr) {
             const a = arr.slice();
-            for (let i = a.length - 1; i > 0; i--) {
+            if (typeof crypto.randomInt === "function") {
+                for (let i = a.length - 1; i > 0; i--) {
+                    const j = crypto.randomInt(i + 1);
+                    [a[i], a[j]] = [a[j], a[i]];
+                }
+            } else {
                 const buf = new Uint32Array(1);
-                crypto.getRandomValues(buf);
-                const j = buf[0] % (i + 1);
-                [a[i], a[j]] = [a[j], a[i]];
+                for (let i = a.length - 1; i > 0; i--) {
+                    const max = i + 1;
+                    const limit = 0x100000000 - (0x100000000 % max);
+                    let r;
+                    do {
+                        crypto.getRandomValues(buf);
+                        r = buf[0];
+                    } while (r >= limit);
+                    const j = r % max;
+                    [a[i], a[j]] = [a[j], a[i]];
+                }
             }
             return a;
         }


### PR DESCRIPTION
## Summary
- use crypto.randomInt when available or a shared Uint32Array to shuffle news
- return 404 when news list missing or invalid

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check functions/api/news.js`

------
https://chatgpt.com/codex/tasks/task_e_68b525816058832782e9721486ad6459