### PR TITLE
完善 Service Worker 的缓存逻辑

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -33,34 +33,33 @@ self.addEventListener('activate', event => {
 // 拦截网络请求并返回缓存的启动页
 self.addEventListener('fetch', event => {
   if (event.request.url.includes('/pwa-loading')) {  // 只拦截 pwa-loading 页面请求
-    event.respondWith(
-      caches.match(event.request)
-        .then(cachedResponse => {
-          // 如果缓存中有该页面，返回缓存的资源
-          if (cachedResponse) {
-            return cachedResponse;
-          }
+    event.respondWith((async () => {
+      const cachedResponse = await caches.match(event.request);
+      // 如果缓存中有该页面，返回缓存的资源
+      if (cachedResponse) {
+        return cachedResponse;
+      }
 
-          // 如果缓存中没有，进行网络请求
-          return fetch(event.request)
-            .then(response => {
-              // 检查响应是否有效
-              if (!response || response.status !== 200 || response.type !== 'basic') {
-                return response;
-              }
+      const response = await fetch(event.request);
+      // 检查响应是否有效
+      if (!response || response.status !== 200 || response.type !== 'basic') {
+        return response;
+      }
 
-              // 克隆响应以便缓存
-              const responseToCache = response.clone();
+      // 克隆响应以便缓存
+      const responseToCache = response.clone();
 
-              // 将响应缓存起来
-              caches.open(CACHE_NAME)
-                .then(cache => {
-                  cache.put(event.request, responseToCache);
-                });
+      // 将响应缓存起来并确保写入完成
+      event.waitUntil((async () => {
+        try {
+          const cache = await caches.open(CACHE_NAME);
+          await cache.put(event.request, responseToCache);
+        } catch (error) {
+          console.error('Failed to cache the response:', error);
+        }
+      })());
 
-              return response;
-            });
-        })
-    );
+      return response;
+    })());
   }
 });


### PR DESCRIPTION
## Summary
- 使用 `async`/`await` 重写 `fetch` 处理器并加入错误日志
- 通过 `event.waitUntil` 确保响应缓存写入完成

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b52fc5b32083278c6afdf8c9ade33e