### PR TITLE
feat: add scrolling intro text to PWA loading screen

### DIFF
--- a/public/pwa-loading.html
+++ b/public/pwa-loading.html
@@ -53,12 +53,65 @@
       transition: opacity 1s ease;
     }
 
-    h1 {
+    .text-container {
       margin-top: 16px;
       font-size: 20px;
       font-weight: 700;
+      line-height: 1.2;
+      height: 1.2em;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .text-container h1 {
+      margin: 0;
+      font: inherit;
+      position: absolute;
+      width: 100%;
       opacity: 0;
       transition: opacity 1.2s ease;
+    }
+
+    .text-container .line2 {
+      transform: translateY(100%);
+    }
+
+    .text-container.show h1 {
+      opacity: 1;
+    }
+
+    .text-container.scroll .line1 {
+      animation: slide-up 2.5s forwards;
+    }
+
+    .text-container.scroll .line2 {
+      animation: slide-up-2 2.5s forwards;
+    }
+
+    @keyframes slide-up {
+      0%, 40% {
+        transform: translateY(0);
+      }
+      60%, 100% {
+        transform: translateY(-100%);
+      }
+    }
+
+    @keyframes slide-up-2 {
+      0%, 40% {
+        transform: translateY(100%);
+      }
+      60%, 100% {
+        transform: translateY(0);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .text-container.scroll .line1,
+      .text-container.scroll .line2 {
+        animation: none;
+        transform: translateY(0);
+      }
     }
 
     .show {
@@ -78,7 +131,10 @@
 <body>
   <div class="wrap">
     <img src="/images/Homepage_Gameplay-Trailer_MC-OV-logo_300x300.png" alt="App logo" class="logo" id="logo" />
-    <h1 id="title">Welcome to MC Share</h1>
+    <div id="title" class="text-container">
+      <h1 class="line1">Minecraft Share</h1>
+      <h1 class="line2">Welcome to MC Share!</h1>
+    </div>
 
     <!-- 网络错误提示 -->
     <div id="error-message" class="error-message">
@@ -90,11 +146,18 @@
   <script src="/javascript/register-sw.js" defer></script>
 
   <script>
-    // 图标 + 文本淡入
+    // 图标 + 文本淡入并滚动
     window.addEventListener('load', () => {
-      document.getElementById('logo').classList.add('show');
+      const logo = document.getElementById('logo');
+      const title = document.getElementById('title');
+      logo.classList.add('show');
       setTimeout(() => {
-        document.getElementById('title').classList.add('show');
+        title.classList.add('show');
+        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+          setTimeout(() => {
+            title.classList.add('scroll');
+          }, 800);
+        }
       }, 300);
     });
 


### PR DESCRIPTION
## Summary
- introduce text container with two headings for "Minecraft Share" and "Welcome to MC Share!"
- add vertical scroll animation with reduced motion fallback
- trigger fade-in then start text scroll on page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68934b98883279ffc4304965cd2f0